### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single Next.js 15 (App Router, React 19, TypeScript) content site — package name `verdesabor`, branded **RenewHabits**. It stores articles in **MongoDB** (database `verdesabor`, collection `articles`).
+
+### Services
+
+| Service | Required | Run command | Notes |
+|---|---|---|---|
+| Next.js app | yes | `npm run dev` (`next dev --turbopack`, port 3000) | Primary dev workflow. |
+| MongoDB | yes | `mongod --dbpath /var/lib/mongodb --bind_ip 127.0.0.1 --port 27017` | App throws at import if `MONGODB_URI` is unset. Started outside the update script. |
+
+### Environment variables (`.env.local`, gitignored — recreate it; it is not committed)
+
+```
+MONGODB_URI=mongodb://127.0.0.1:27017
+ADMIN_USER=admin
+ADMIN_PASSWORD=changeme
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+```
+
+- `MONGODB_URI` is required or the app throws on startup (`src/lib/mongodb.ts`, `src/lib/getArticleBySlug.ts`).
+- `ADMIN_USER` / `ADMIN_PASSWORD` gate the `/login` -> `/adminpage` flow.
+- `NEXT_PUBLIC_SITE_URL` must point at a running instance of this app; the article detail page (`src/app/articles/[slug]/page.tsx`) and `src/app/sitemap.ts` fetch `${NEXT_PUBLIC_SITE_URL}/api/articles[...]` **server-side**, so it must resolve to a live server (use `http://localhost:3000` locally).
+
+### Seeding data
+
+Article read APIs return empty/404 until the `verdesabor.articles` collection has data. Seed via the admin UI (`/login` then `/adminpage`) or insert documents matching the POST handler shape in `src/app/api/articles/route.js` (`slug, image, title, category, excerpt, imagel, imagexl, text, image2xl, text2, publishedAt`). Valid categories: Nutrition, Biohacking, Neuroscience, Wellness, Lifestyle, Longevity.
+
+### Build / lint gotchas (non-obvious)
+
+- **`npm run build` cannot complete standalone.** `src/app/sitemap.ts` (and article pages) `fetch ${NEXT_PUBLIC_SITE_URL}/api/articles` during static generation, so the build only succeeds when that URL points at a separate, already-running, stable API instance (on Vercel it points at the live deployment). Do not run `next build` against the same `.next` dir while `next dev` is running — they collide. The supported local workflow is `npm run dev`.
+- **`npm run lint` is not configured.** `next lint` launches an interactive ESLint setup prompt because the repo ships no ESLint config; it cannot run non-interactively as-is.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Next.js 15 + MongoDB content site (`verdesabor` / RenewHabits) and documents how to run it for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the required services (Next.js dev server + MongoDB), required env vars, data seeding, and build/lint gotchas.

## Environment setup performed (not committed; recreated each run)

- `npm install` for Node dependencies.
- MongoDB 8.0 installed and run locally on `127.0.0.1:27017`.
- `.env.local` created with `MONGODB_URI`, `ADMIN_USER`, `ADMIN_PASSWORD`, `NEXT_PUBLIC_SITE_URL` (gitignored).
- Seeded `verdesabor.articles` with sample articles across all categories.

## Notes

- `npm run dev` is the supported workflow and works end-to-end (homepage, category pages, article detail, `/api/articles`, admin create flow).
- `npm run build` cannot complete standalone: `sitemap.ts`/article pages self-fetch `${NEXT_PUBLIC_SITE_URL}/api/articles` during static generation (designed to build on Vercel against the live URL).
- `npm run lint` is not configured (`next lint` opens an interactive ESLint setup prompt; repo ships no ESLint config).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ada7755-8ec2-4732-b312-578e718e961d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ada7755-8ec2-4732-b312-578e718e961d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

